### PR TITLE
Support moduleResolution bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "exports": {
     ".": {
       "import": "./lib/Constrainautor.mjs",
-      "require": "./lib/Constrainautor.cjs"
+      "require": "./lib/Constrainautor.cjs",
+      "types": "./Constrainautor.ts"
     },
     "./min": {
       "import": "./lib/Constrainautor.min.mjs",
-      "require": "./lib/Constrainautor.min.js"
+      "require": "./lib/Constrainautor.min.js",
+      "types": "./Constrainautor.ts"
     }
   },
   "types": "Constrainautor.ts",


### PR DESCRIPTION
Thanks for your library, it's awesome!

However, I can't get the types when I set "moduleResolution": "bundler" in `tsconfig.json`:
```
There are types at 'xxx/@kninnug/constrainautor/Constrainautor.ts', but this result could not be resolved when respecting package.json "exports". The '@kninnug/constrainautor' library may need to update its package.json or typings.
```

Since more and more projects are using ⁠"moduleResolution": "bundler" as the default config, it would be great if support it.